### PR TITLE
Fix/redirects

### DIFF
--- a/app/_components/HamburgerMenu.tsx
+++ b/app/_components/HamburgerMenu.tsx
@@ -75,11 +75,11 @@ const HamburgerMenu: React.FC = () => {
       </button>
       <nav
         ref={menuRef}
-        className={`fixed right-0 top-0 bottom-0 w-[85%] bg-white rounded-xl sm:hidden h-screen p-6 ease-in duration-300 z-100 overflow-hidden ${
+        className={`fixed right-0 top-0 bottom-0 w-[85%] bg-white rounded-xl sm:hidden h-min-screen p-6 ease-in duration-300 z-100 overflow-hidden ${
           menuOpen ? "fixed" : "hidden"
         }`}
       >
-        <div className="flex w-[90%] mt-8 mb-5 items-center justify-between">
+        <div className="flex w-[90%] mt-5 mb-4 items-center justify-between">
           <Image
             src="/small-logo.png"
             alt="company logo"
@@ -91,7 +91,7 @@ const HamburgerMenu: React.FC = () => {
             <ExitCrossFC />
           </div>
         </div>
-        <div className="flex-col py-4 overflow-hidden">
+        <div className="flex-col py-3 overflow-hidden">
           <ul className="text-md gap-2">
             {linkGroups.map((group, index) => (
               <div key={index}>{renderLinks(group)}</div>

--- a/app/_components/Navbar.tsx
+++ b/app/_components/Navbar.tsx
@@ -7,6 +7,7 @@ const Navbar: React.FC = () => {
     <nav className="block w-auto max-w-screen-xxl my-6 py-3 mx-6 xl:mx-20 text-neutralDark  lg:bg-white lg:rounded-xl  lg:backdrop-blur-xl lg:backdrop-saturate-200">
       <div className="flex justify-between items-center">
         <div className="flex items-center gap-1 md:gap-20">
+          <Link href="/">
           <Image
             src="/Logo1findclinics.png"
             alt="company logo"
@@ -21,6 +22,7 @@ const Navbar: React.FC = () => {
             height={25}
             className="mr-8 block cursor-pointer lg:hidden"
           />
+          </Link>
 
           <div className="hidden md:flex items-center justify-center w-full h-full gap-8 text-base">
             <ul className="inline-flex gap-8">
@@ -38,12 +40,6 @@ const Navbar: React.FC = () => {
                 </Link>
               </li>
               <li className="block p-2 antialiased leading-normal hover:rounded-l hover:bg-neutral hover:rounded-lg">
-                <Link
-                  href="/contactus"
-                  className="flex items-center hover:underline whitespace-nowrap"
-                >
-                  Contact Us
-                </Link>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
The logo in the header now redirects to the main page when clicked
The Contact Us button removed from the navbar
some margins and padding were slightly decreased in the hamb menu to arrange a better view on smaller phones